### PR TITLE
feat: add :custom validation rule

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -18,8 +18,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: erlef/setup-beam@v1
         with:
-          elixir-version: "1.16.2"
-          otp-version: "26.2"
+          elixir-version: "1.18.3"
+          otp-version: "27"
       - uses: actions/cache@v3
         with:
           path: deps

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Goal
+### NOTE- this is a maintained fork of [Goal](https://github.com/martinthenth/goal) with extra functionality
 
-[![CI](https://github.com/martinthenth/goal/actions/workflows/elixir.yml/badge.svg)](https://github.com/martinthenth/goal/actions/workflows/elixir.yml)
+[![CI](https://github.com/mtanca/goal/actions/workflows/elixir.yml/badge.svg)](https://github.com/mtanca/goal/actions/workflows/elixir.yml)
 [![Hex.pm](https://img.shields.io/hexpm/v/goal)](https://hex.pm/packages/goal)
 [![Hex.pm](https://img.shields.io/hexpm/dt/goal)](https://hex.pm/packages/goal)
-[![Hex.pm](https://img.shields.io/hexpm/l/goal)](https://github.com/martinthenth/goal/blob/main/LICENSE)
+[![Hex.pm](https://img.shields.io/hexpm/l/goal)](https://github.com/mtanca/goal/blob/main/LICENSE)
 
 Goal is a parameter validation library based on [Ecto](https://github.com/elixir-ecto/ecto).
 It can be used with JSON APIs, HTML controllers and LiveViews.
@@ -308,7 +309,7 @@ The field types and available validations are:
 |                        | `:is`                       | exact string length                                                                                  |
 |                        | `:min`                      | minimum string length                                                                                |
 |                        | `:max`                      | maximum string length                                                                                |
-|                        | `:trim`                     | boolean to remove leading and trailing spaces                                                         |
+|                        | `:trim`                     | boolean to remove leading and trailing spaces                                                        |
 |                        | `:squish`                   | boolean to trim and collapse spaces                                                                  |
 |                        | `:format`                   | `:uuid`, `:email`, `:password`, `:url`                                                               |
 |                        | `:subset`                   | list of required strings                                                                             |
@@ -340,6 +341,7 @@ The field types and available validations are:
 |                        | `:max`                      | maximum array length                                                                                 |
 |                        | `:is`                       | exact array length                                                                                   |
 | More basic types       |                             | See [Ecto.Schema](https://hexdocs.pm/ecto/Ecto.Schema.html#module-primitive-types) for the full list |
+| Custom Validations     | `:custom`                   | expects a function taking a field name, params map, and a changeset, returning a changeset           |
 
 All field types, excluding `:map` and `{:array, :map}`, can use `:equals`, `:subset`,
 `:included`, `:excluded` validations.


### PR DESCRIPTION
Adds a new `:custom` rule to give more control over what types of param validations you want run which `Goal` doesn't/shouldn't support when evaluating a param.

The proposed `:custom` opt takes a function which accpets the current field, the params map (changeset.changes), and current changeset and returns a changeset.


**Example:**
```elixir 
defparams :custom_validation do
  optional(:is_home_address?, :boolean)
  optional(:age, :integer)
  optional(:address, :string,
    custom: fn field, params, changeset ->
      # A simple "required if" validation case where the `address` is only required when
      # both `age` and `is_home_address?` fields are present in the params map
      case params do
        %{age: _age, is_home_address?: true} ->
          Ecto.Changeset.add_error(changeset, field, """
          is required when age and is_home_address? are present
          """)
        _ ->
          changeset
      end
    end
  )
end
```